### PR TITLE
Update tests and test script for latest version of weaver and manifes…

### DIFF
--- a/buildscripts/test_weaver_policies.sh
+++ b/buildscripts/test_weaver_policies.sh
@@ -99,7 +99,7 @@ check_output() {
       
       # Filter out Weaver's unstable version warnings from observed file for comparison
       # We expect the expected file to ALREADY be clean of these warnings.
-      VERSION_FILTER='map(select(.diagnostic.message | contains("Version `2` schema file format is not yet stable") | not))'
+      VERSION_FILTER='map(select(.diagnostic.message | contains("is not yet stable") | not))'
 
       # Normalize empty/null/missing context so tests are robust to omitting context: {}.
       # Also strips the ", context={}" segment from the human-readable diagnostic message.
@@ -258,7 +258,7 @@ run_policy_test() {
     # Strip coverage report or any other non-JSON output before passing to jq
     # Also filter out Weaver's unstable version warnings
     # TODO - extract coverage report into separate file for display.
-    JQ_FILTER='map(select(.diagnostic.message | contains("Version `2` schema file format is not yet stable") | not))'
+    JQ_FILTER='map(select(.diagnostic.message | contains("is not yet stable") | not))'
     sed -n '/^\[/,$p' "${RAW_DIAGNOSTIC_OUTPUT}" | jq -S "${JQ_FILTER}" > "${OBSERVED_DIR}/diagnostic-output.json"
   fi
   check_output "${OBSERVED_DIR}/diagnostic-output.json" "${TEST_DIR}/expected-diagnostic-output.json" "${TEST_NAME} - Diagnostic Output"

--- a/policies/check/AGENTS.md
+++ b/policies/check/AGENTS.md
@@ -109,7 +109,7 @@ Key paths in `input`:
 
 #### V2 Test Models (`model.yaml`)
 
-Models using `version: '2'` must strictly adhere to the V2 semantic convention structure. For example, `attribute_groups` require `id`, `stability`, `visibility`, `brief`, and `attributes`.
+Models using `file_format: definition/2` must strictly adhere to the V2 semantic convention structure. For example, `attribute_groups` require `id`, `stability`, `visibility`, `brief`, and `attributes`.
 
 #### Handling V2 Schema Warnings
 

--- a/policies/check/backwards-compatibility/tests/attribute/base/model.yaml
+++ b/policies/check/backwards-compatibility/tests/attribute/base/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: is.dropped
     type: string

--- a/policies/check/backwards-compatibility/tests/attribute/current/model.yaml
+++ b/policies/check/backwards-compatibility/tests/attribute/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: is.change_stable
     type: string

--- a/policies/check/backwards-compatibility/tests/entities/base/model.yaml
+++ b/policies/check/backwards-compatibility/tests/entities/base/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/entities/current/model.yaml
+++ b/policies/check/backwards-compatibility/tests/entities/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/events/base/model.yaml
+++ b/policies/check/backwards-compatibility/tests/events/base/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/events/current/model.yaml
+++ b/policies/check/backwards-compatibility/tests/events/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/metrics/base/model.yaml
+++ b/policies/check/backwards-compatibility/tests/metrics/base/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/metrics/current/model.yaml
+++ b/policies/check/backwards-compatibility/tests/metrics/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/spans/base/model.yaml
+++ b/policies/check/backwards-compatibility/tests/spans/base/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/backwards-compatibility/tests/spans/current/model.yaml
+++ b/policies/check/backwards-compatibility/tests/spans/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: a
     brief: a attribute

--- a/policies/check/naming_conventions/tests/all_valid/current/model.yaml
+++ b/policies/check/naming_conventions/tests/all_valid/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: valid.attr
     type: string

--- a/policies/check/naming_conventions/tests/attribute_complex_type_violation/current/model.yaml
+++ b/policies/check/naming_conventions/tests/attribute_complex_type_violation/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: test.complex
     type: template[any]

--- a/policies/check/naming_conventions/tests/attribute_constant_collision/current/model.yaml
+++ b/policies/check/naming_conventions/tests/attribute_constant_collision/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: namespace.test.attribute
     type: string

--- a/policies/check/naming_conventions/tests/metric_brief_period/current/model.yaml
+++ b/policies/check/naming_conventions/tests/metric_brief_period/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 metrics:
   - name: test.metric
     brief: A test metric without period

--- a/policies/check/naming_conventions/tests/metric_namespace_collision/current/model.yaml
+++ b/policies/check/naming_conventions/tests/metric_namespace_collision/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 metrics:
   - name: test.metric
     brief: A test metric.

--- a/policies/check/naming_conventions/tests/names_violations/current/model.yaml
+++ b/policies/check/naming_conventions/tests/names_violations/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: nonamespace
     type: string

--- a/policies/check/stability/tests/attribute_renamed_to_invalid/current/model.yaml
+++ b/policies/check/stability/tests/attribute_renamed_to_invalid/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: old.attr
     brief: old attribute

--- a/policies/check/stability/tests/attribute_renamed_to_type_mismatch/current/model.yaml
+++ b/policies/check/stability/tests/attribute_renamed_to_type_mismatch/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: old.string.attr
     brief: old string attribute

--- a/policies/check/stability/tests/attribute_renamed_to_valid/current/model.yaml
+++ b/policies/check/stability/tests/attribute_renamed_to_valid/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: old.attr
     brief: old attribute

--- a/policies/check/stability/tests/entity_experimental_attribute/current/model.yaml
+++ b/policies/check/stability/tests/entity_experimental_attribute/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: experimental.attr
     brief: experimental attribute

--- a/policies/check/stability/tests/entity_no_identity/current/model.yaml
+++ b/policies/check/stability/tests/entity_no_identity/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: test.attr
     brief: A test attribute

--- a/policies/check/stability/tests/enum_member_renamed_to_invalid/current/model.yaml
+++ b/policies/check/stability/tests/enum_member_renamed_to_invalid/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: test.enum
     brief: test enum

--- a/policies/check/stability/tests/event_experimental_attribute/current/model.yaml
+++ b/policies/check/stability/tests/event_experimental_attribute/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: experimental.attr
     brief: experimental attribute

--- a/policies/check/stability/tests/metric_experimental_attribute/current/model.yaml
+++ b/policies/check/stability/tests/metric_experimental_attribute/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: experimental.attr
     brief: experimental attribute

--- a/policies/check/stability/tests/metric_renamed_to_invalid/current/model.yaml
+++ b/policies/check/stability/tests/metric_renamed_to_invalid/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 metrics:
   - name: old.metric
     brief: old metric

--- a/policies/check/stability/tests/span_experimental_attribute/current/model.yaml
+++ b/policies/check/stability/tests/span_experimental_attribute/current/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
   - key: experimental.attr
     brief: experimental attribute

--- a/templates/docs/markdown/tests/basic_test/registry/model.yaml
+++ b/templates/docs/markdown/tests/basic_test/registry/model.yaml
@@ -1,4 +1,4 @@
-version: '2'
+file_format: definition/2
 attributes:
 - key: my.key
   type: string


### PR DESCRIPTION
…t file.

- Tests now just ignore `is not yet stable` warnings for V2 vs. a longer string. (This may be too aggressive, but plan to cut this ASAP)
- Update all manifests to use the new `file_format` instead of `version`