### PR TITLE
Fix markdown templates for attribute examples

### DIFF
--- a/templates/docs/markdown/attributes.md.j2
+++ b/templates/docs/markdown/attributes.md.j2
@@ -8,14 +8,24 @@ This document describes the `{{ ctx.root_namespace }}` attributes.
 
 {{ attribute.brief | trim }}
 
-{% if attribute.note %}{{ attribute.note | trim }}{% endif %}
+{% if attribute.note %}{{ attribute.note | trim }}
 
-{% if attribute.examples is defined %}{% if attribute.examples is sequence %}**Examples**: `{{ attribute.examples | join("`, `") }}`{% else %}**Examples**: `{{ attribute.examples }}`{% endif %}{% endif %}
+{% endif %}
+{% if attribute.examples is defined %}
+{% if attribute.examples is sequence %}
+**Examples**: `{{ attribute.examples | join("`, `") }}`
+{% else %}
+**Examples**: `{{ attribute.examples }}`
+{% endif %}
 
-**Type**: {% if attribute is enum %}enum{% else %}`{{ attribute.type }}`{% endif %}
+{% endif %}
+{% if attribute is enum %}
+**Type**: enum
+{% else %}
+**Type**: `{{ attribute.type }}`
+{% endif %}
 
 {% if attribute is enum and attribute.type.members %}
-
 | Value | Description |
 |-------|-------------|
 {% for member in attribute.type.members %}| `{{ member.value }}` | {{ member.brief | default() | trim }} |

--- a/templates/docs/markdown/attributes.md.j2
+++ b/templates/docs/markdown/attributes.md.j2
@@ -10,7 +10,7 @@ This document describes the `{{ ctx.root_namespace }}` attributes.
 
 {% if attribute.note %}{{ attribute.note | trim }}{% endif %}
 
-{% if attribute.examples %}**Examples**: `{{ attribute.examples | join("`, `") }}`{% endif %}
+{% if attribute.examples is defined %}{% if attribute.examples is sequence %}**Examples**: `{{ attribute.examples | join("`, `") }}`{% else %}**Examples**: `{{ attribute.examples }}`{% endif %}{% endif %}
 
 **Type**: {% if attribute is enum %}enum{% else %}`{{ attribute.type }}`{% endif %}
 

--- a/templates/docs/markdown/tests/attributes/expected/some/attributes.md
+++ b/templates/docs/markdown/tests/attributes/expected/some/attributes.md
@@ -6,21 +6,21 @@ This document describes the `some` attributes.
 
 An attribute with an array of examples
 
-
 **Examples**: `one`, `two`
+
 **Type**: `string`
+
 ## `some.array_of_arrays_examples` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An array-typed attribute with array-of-arrays examples
 
-
 **Examples**: `["a", "b"]`, `["c"]`
+
 **Type**: `string[]`
+
 ## `some.enum` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An enum attribute
-
-
 
 **Type**: enum
 
@@ -33,34 +33,37 @@ An enum attribute
 
 A key in my registry
 
-
-
 **Type**: `string`
+
 ## `some.scalar_bool_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An attribute with a single scalar boolean example
 
-
 **Examples**: `false`
+
 **Type**: `boolean`
+
 ## `some.scalar_int_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An attribute with a single scalar int example
 
-
 **Examples**: `42`
+
 **Type**: `int`
+
 ## `some.scalar_string_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An attribute with a single scalar string example
 
-
 **Examples**: `solo`
+
 **Type**: `string`
+
 ## `some.scalar_zero_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An attribute with a single falsy scalar example
 
-
 **Examples**: `0`
+
 **Type**: `int`
+

--- a/templates/docs/markdown/tests/attributes/expected/some/attributes.md
+++ b/templates/docs/markdown/tests/attributes/expected/some/attributes.md
@@ -2,6 +2,20 @@
 
 This document describes the `some` attributes.
 
+## `some.array_examples` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
+
+An attribute with an array of examples
+
+
+**Examples**: `one`, `two`
+**Type**: `string`
+## `some.array_of_arrays_examples` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
+
+An array-typed attribute with array-of-arrays examples
+
+
+**Examples**: `["a", "b"]`, `["c"]`
+**Type**: `string[]`
 ## `some.enum` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 An enum attribute
@@ -22,3 +36,31 @@ A key in my registry
 
 
 **Type**: `string`
+## `some.scalar_bool_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
+
+An attribute with a single scalar boolean example
+
+
+**Examples**: `false`
+**Type**: `boolean`
+## `some.scalar_int_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
+
+An attribute with a single scalar int example
+
+
+**Examples**: `42`
+**Type**: `int`
+## `some.scalar_string_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
+
+An attribute with a single scalar string example
+
+
+**Examples**: `solo`
+**Type**: `string`
+## `some.scalar_zero_example` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
+
+An attribute with a single falsy scalar example
+
+
+**Examples**: `0`
+**Type**: `int`

--- a/templates/docs/markdown/tests/attributes/registry/model.yaml
+++ b/templates/docs/markdown/tests/attributes/registry/model.yaml
@@ -15,3 +15,35 @@ attributes:
         brief: Second value
   brief: An enum attribute
   stability: stable
+- key: some.scalar_int_example
+  type: int
+  brief: An attribute with a single scalar int example
+  stability: stable
+  examples: 42
+- key: some.scalar_zero_example
+  type: int
+  brief: An attribute with a single falsy scalar example
+  stability: stable
+  examples: 0
+- key: some.scalar_string_example
+  type: string
+  brief: An attribute with a single scalar string example
+  stability: stable
+  examples: "solo"
+- key: some.scalar_bool_example
+  type: boolean
+  brief: An attribute with a single scalar boolean example
+  stability: stable
+  examples: false
+- key: some.array_examples
+  type: string
+  brief: An attribute with an array of examples
+  stability: stable
+  examples: ["one", "two"]
+- key: some.array_of_arrays_examples
+  type: string[]
+  brief: An array-typed attribute with array-of-arrays examples
+  stability: stable
+  examples:
+    - ["a", "b"]
+    - ["c"]

--- a/templates/docs/markdown/tests/entities/expected/some/attributes.md
+++ b/templates/docs/markdown/tests/entities/expected/some/attributes.md
@@ -6,13 +6,11 @@ This document describes the `some` attributes.
 
 A descriptive attribute
 
-
-
 **Type**: `string`
+
 ## `some.key` ![Stable](https://img.shields.io/badge/-stable-lightgreen)
 
 A key in my registry
 
-
-
 **Type**: `string`
+

--- a/templates/docs/markdown/tests/events/expected/some/attributes.md
+++ b/templates/docs/markdown/tests/events/expected/some/attributes.md
@@ -6,6 +6,5 @@ This document describes the `some` attributes.
 
 A key in my registry
 
-
-
 **Type**: `string`
+

--- a/templates/docs/markdown/tests/metrics/expected/some/attributes.md
+++ b/templates/docs/markdown/tests/metrics/expected/some/attributes.md
@@ -6,6 +6,5 @@ This document describes the `some` attributes.
 
 A key in my registry
 
-
-
 **Type**: `string`
+

--- a/templates/docs/markdown/tests/spans/expected/some/attributes.md
+++ b/templates/docs/markdown/tests/spans/expected/some/attributes.md
@@ -6,6 +6,5 @@ This document describes the `some` attributes.
 
 A key in my registry
 
-
-
 **Type**: `string`
+


### PR DESCRIPTION
The template didn't work for scalar examples. Added support and tests for all example types.

Fixed rendering: a newline was missing between Examples and Type so these would appear on the same line (depending on your renderer).