### PR TITLE
Add public attribute groups to back compat and stability checks

### DIFF
--- a/policies/check/backwards-compatibility/README.md
+++ b/policies/check/backwards-compatibility/README.md
@@ -5,6 +5,12 @@ This package provides backwards compatibility guarantees required by OpenTelemet
 Stability: Development
 Owners: @open-telemetry/specs-semconv-maintainers
 
+## Details
+
+This package checks the current registry against a baseline registry and reports
+breaking changes to attributes, metrics, entities, events, spans, and public
+attribute groups.
+
 ## Usage
 
 ```bash

--- a/policies/check/backwards-compatibility/compat.rego
+++ b/policies/check/backwards-compatibility/compat.rego
@@ -15,6 +15,7 @@ registry_metric_names := { metric.name | some metric in input.registry.metrics }
 registry_entity_types := { entity.type | some entity in input.registry.entities }
 registry_event_names := { event.name | some event in input.registry.events }
 registry_span_types := { span.type | some span in input.registry.spans }
+registry_attribute_group_ids := { group.id | some group in input.registry.attribute_groups }
 
 
 # Rules we enforce:
@@ -46,6 +47,14 @@ registry_span_types := { span.type | some span in input.registry.spans }
 #   - [x] Stable spans cannot become unstable
 #   - [x] Stable attributes cannot be dropped from stable span
 #   - [x] Span kind cannot change on stable spans.
+# - Attribute groups - PUBLIC groups only.
+#   Internal groups are an authoring convenience: they are not part of the
+#   resolved registry, nobody outside the registry can reference them, and
+#   they may change or disappear at any time.
+#   - [x] public attribute groups cannot be removed
+#   - [x] Stable public attribute groups cannot become unstable
+#   - [x] Attributes cannot be dropped from a stable public attribute group
+#   - [x] Non-opt_in attributes cannot be added to a stable public attribute group
 
 # Rule: Detect Removed Attributes
 #
@@ -744,6 +753,133 @@ deny contains finding if {
         "level": "violation",
         "signal_type": "span",
         "signal_name": span.type,
+    }
+}
+
+# Rule: Detect Removed Public Attribute Groups
+#
+# This rule checks for public attribute groups that existed in the baseline
+# registry but are no longer present in the current registry. Consumers
+# reference a public group as a whole, so removing one is a breaking change.
+#
+# In other words, we do not allow the removal of a public attribute group once
+# added to semantic conventions. They, however, may be deprecated.
+#
+# Internal attribute groups never reach the resolved registry, so they are not
+# covered by any of the rules below.
+deny contains finding if {
+    # Find data we need to enforce
+    some group in data.registry.attribute_groups
+
+    # Enforce the policy
+    not registry_attribute_group_ids[group.id]
+
+    # Generate human readable error.
+    finding := {
+        "id": "compatibility_attribute_group_removed",
+        "context": {
+            "attribute_group_id": group.id,
+        },
+        "message": sprintf("Attribute group '%s' no longer exists in semantic conventions", [group.id]),
+        "level": "violation",
+    }
+}
+
+
+# Rule: Stable public attribute groups cannot become unstable
+#
+# This rule checks that stable public attribute groups cannot have their
+# stability level changed.
+deny contains finding if {
+    # Find data we need to enforce
+    some group in data.registry.attribute_groups
+    group.stability == "stable"
+    some ngroup in input.registry.attribute_groups
+    group.id == ngroup.id
+    # Enforce the policy
+    ngroup.stability != "stable"
+
+    # Generate human readable error.
+    finding := {
+        "id": "compatibility_attribute_group_changed_stability",
+        "context": {
+            "attribute_group_id": group.id,
+        },
+        "message": sprintf("Attribute group '%s' cannot change from stable", [group.id]),
+        "level": "violation",
+    }
+}
+
+
+# Rule: Attributes on a stable public attribute group cannot be dropped.
+#
+# This rule checks that stable public attribute groups have stable sets of
+# attributes. Opt_in attributes are covered too: a consumer in another registry
+# may already be emitting them.
+deny contains finding if {
+    # Find data we need to enforce
+    some group in data.registry.attribute_groups
+    group.stability == "stable"
+    some ngroup in input.registry.attribute_groups
+    group.id == ngroup.id
+
+    baseline_attributes := { attr.key |
+        some attr in group.attributes
+    }
+    new_attributes := { attr.key |
+        some attr in ngroup.attributes
+    }
+    missing_attributes := baseline_attributes - new_attributes
+    # Enforce the policy
+    count(missing_attributes) > 0
+
+    # Generate human readable error.
+    finding := {
+        "id": "compatibility_attribute_group_dropped_attributes",
+        "context": {
+            "attribute_group_id": group.id,
+            "missing_attributes": missing_attributes,
+        },
+        "message": sprintf("Attribute group '%s' cannot remove attributes (missing '%s')", [group.id, missing_attributes]),
+        "level": "violation",
+    }
+}
+
+# Rule: Non-opt_in attributes cannot be added to a stable public attribute group.
+#
+# Public groups are referenced across registries: a signal in another registry
+# that includes this group silently gains every attribute added here. Adding a
+# required or recommended attribute therefore changes that signal's attribute
+# set without its owner making any change. Opt_in attributes are not emitted
+# unless a user asks for them, so adding those is allowed.
+deny contains finding if {
+    # Find data we need to enforce
+    some group in data.registry.attribute_groups
+    group.stability == "stable"
+    some ngroup in input.registry.attribute_groups
+    group.id == ngroup.id
+
+    baseline_attributes := { attr.key |
+        some attr in group.attributes
+        not is_opt_in(attr)
+    }
+    new_attributes := { attr.key |
+        some attr in ngroup.attributes
+        not is_opt_in(attr)
+    }
+    added_attributes := new_attributes - baseline_attributes
+    # Enforce the policy
+    count(added_attributes) > 0
+
+    # Generate human readable error.
+    finding := {
+        "id": "compatibility_attribute_group_added_attributes",
+        "context": {
+            "attribute_group_id": group.id,
+            "added_attributes": added_attributes,
+        },
+        "message": sprintf("Attribute group '%s' cannot add required/recommended attributes (added '%s')", [group.id, added_attributes]),
+        "level": "violation",
     }
 }
 

--- a/policies/check/backwards-compatibility/tests/attribute_groups/base/model.yaml
+++ b/policies/check/backwards-compatibility/tests/attribute_groups/base/model.yaml
@@ -1,0 +1,51 @@
+file_format: definition/2
+attributes:
+  - key: a
+    brief: a attribute
+    type: string
+    stability: stable
+  - key: b
+    brief: b attribute
+    type: string
+    stability: stable
+  - key: c
+    brief: c attribute
+    type: string
+    stability: stable
+  - key: d
+    brief: d attribute
+    type: string
+    stability: stable
+attribute_groups:
+  - id: some.missing.group
+    brief: this will be missing
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+  - id: some.group.change_stability
+    brief: this will change stability
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+  - id: some.group.missing.attrs
+    brief: this will be missing b and c attributes
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+      - ref: b
+      - ref: c
+  - id: some.group.added.attrs
+    brief: this will gain a recommended attribute
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+  - id: some.group.added.opt_in.attrs
+    brief: this will gain an opt_in attribute, which is allowed
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a

--- a/policies/check/backwards-compatibility/tests/attribute_groups/current/model.yaml
+++ b/policies/check/backwards-compatibility/tests/attribute_groups/current/model.yaml
@@ -1,0 +1,46 @@
+file_format: definition/2
+attributes:
+  - key: a
+    brief: a attribute
+    type: string
+    stability: stable
+  - key: b
+    brief: b attribute
+    type: string
+    stability: stable
+  - key: c
+    brief: c attribute
+    type: string
+    stability: stable
+  - key: d
+    brief: d attribute
+    type: string
+    stability: stable
+attribute_groups:
+  - id: some.group.change_stability
+    brief: this will change stability
+    stability: alpha
+    visibility: public
+    attributes:
+      - ref: a
+  - id: some.group.missing.attrs
+    brief: this will be missing b and c attributes
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+  - id: some.group.added.attrs
+    brief: this will gain a recommended attribute
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+      - ref: d
+  - id: some.group.added.opt_in.attrs
+    brief: this will gain an opt_in attribute, which is allowed
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: a
+      - ref: d
+        requirement_level: opt_in

--- a/policies/check/backwards-compatibility/tests/attribute_groups/expected-diagnostic-output.json
+++ b/policies/check/backwards-compatibility/tests/attribute_groups/expected-diagnostic-output.json
@@ -1,0 +1,89 @@
+[
+  {
+    "diagnostic": {
+      "message": "Policy violation: id=compatibility_attribute_group_added_attributes, context={\"added_attributes\":[\"d\"],\"attribute_group_id\":\"some.group.added.attrs\"}, message=Attribute group 'some.group.added.attrs' cannot add required/recommended attributes (added '{\"d\"}'), level=Violation, signal_type=None, signal_name=None, provenance: current"
+    },
+    "error": {
+      "provenance": "current",
+      "type": "policy_violation",
+      "violation": {
+        "context": {
+          "added_attributes": [
+            "d"
+          ],
+          "attribute_group_id": "some.group.added.attrs"
+        },
+        "id": "compatibility_attribute_group_added_attributes",
+        "level": "violation",
+        "message": "Attribute group 'some.group.added.attrs' cannot add required/recommended attributes (added '{\"d\"}')",
+        "signal_name": null,
+        "signal_type": null,
+        "type": "PolicyFinding"
+      }
+    }
+  },
+  {
+    "diagnostic": {
+      "message": "Policy violation: id=compatibility_attribute_group_changed_stability, context={\"attribute_group_id\":\"some.group.change_stability\"}, message=Attribute group 'some.group.change_stability' cannot change from stable, level=Violation, signal_type=None, signal_name=None, provenance: current"
+    },
+    "error": {
+      "provenance": "current",
+      "type": "policy_violation",
+      "violation": {
+        "context": {
+          "attribute_group_id": "some.group.change_stability"
+        },
+        "id": "compatibility_attribute_group_changed_stability",
+        "level": "violation",
+        "message": "Attribute group 'some.group.change_stability' cannot change from stable",
+        "signal_name": null,
+        "signal_type": null,
+        "type": "PolicyFinding"
+      }
+    }
+  },
+  {
+    "diagnostic": {
+      "message": "Policy violation: id=compatibility_attribute_group_dropped_attributes, context={\"attribute_group_id\":\"some.group.missing.attrs\",\"missing_attributes\":[\"b\",\"c\"]}, message=Attribute group 'some.group.missing.attrs' cannot remove attributes (missing '{\"b\", \"c\"}'), level=Violation, signal_type=None, signal_name=None, provenance: current"
+    },
+    "error": {
+      "provenance": "current",
+      "type": "policy_violation",
+      "violation": {
+        "context": {
+          "attribute_group_id": "some.group.missing.attrs",
+          "missing_attributes": [
+            "b",
+            "c"
+          ]
+        },
+        "id": "compatibility_attribute_group_dropped_attributes",
+        "level": "violation",
+        "message": "Attribute group 'some.group.missing.attrs' cannot remove attributes (missing '{\"b\", \"c\"}')",
+        "signal_name": null,
+        "signal_type": null,
+        "type": "PolicyFinding"
+      }
+    }
+  },
+  {
+    "diagnostic": {
+      "message": "Policy violation: id=compatibility_attribute_group_removed, context={\"attribute_group_id\":\"some.missing.group\"}, message=Attribute group 'some.missing.group' no longer exists in semantic conventions, level=Violation, signal_type=None, signal_name=None, provenance: current"
+    },
+    "error": {
+      "provenance": "current",
+      "type": "policy_violation",
+      "violation": {
+        "context": {
+          "attribute_group_id": "some.missing.group"
+        },
+        "id": "compatibility_attribute_group_removed",
+        "level": "violation",
+        "message": "Attribute group 'some.missing.group' no longer exists in semantic conventions",
+        "signal_name": null,
+        "signal_type": null,
+        "type": "PolicyFinding"
+      }
+    }
+  }
+]

--- a/policies/check/stability/README.md
+++ b/policies/check/stability/README.md
@@ -37,7 +37,10 @@ This package enforces stability restrictions for OpenTelemetry semantic-conventi
   `development`/`experimental` < `alpha` < `beta` < `release_candidate` < `stable`,
   so this catches both a stable metric referencing a development attribute and,
   e.g., a `release_candidate` span referencing a `development` attribute. The
-  finding id is `stability_<signal>_lower_stability_attribute`.
+  finding id is `stability_<signal>_lower_stability_attribute`. Public
+  attribute groups are covered by this rule too (`signal` is `attribute_group`),
+  since other registries may reference them; internal groups are not part of the
+  resolved registry and are not checked.
 
 ### Exceptions
 

--- a/policies/check/stability/stability.rego
+++ b/policies/check/stability/stability.rego
@@ -61,6 +61,7 @@ deny contains finding if {
 
 # Flattened view of every (signal, attribute) pair subject to the stability check.
 # Entities contribute both their identity and description attributes.
+# Public attribute groups are included as well.
 signal_attribute contains item if {
     some metric in input.registry.metrics
     some attr in metric.attributes
@@ -77,6 +78,12 @@ signal_attribute contains item if {
     some span in input.registry.spans
     some attr in span.attributes
     item := {"signal_type": "span", "signal_name": span.type, "signal": span, "attr": attr}
+}
+
+signal_attribute contains item if {
+    some group in input.registry.attribute_groups
+    some attr in group.attributes
+    item := {"signal_type": "attribute_group", "signal_name": group.id, "signal": group, "attr": attr}
 }
 
 signal_attribute contains item if {

--- a/policies/check/stability/tests/attribute_group_experimental_attribute/current/model.yaml
+++ b/policies/check/stability/tests/attribute_group_experimental_attribute/current/model.yaml
@@ -1,0 +1,25 @@
+file_format: definition/2
+attributes:
+  - key: experimental.attr
+    brief: experimental attribute
+    type: string
+    stability: development
+  - key: opt_in.experimental.attr
+    brief: experimental attribute captured on demand
+    type: string
+    stability: development
+attribute_groups:
+  - id: stable.group
+    brief: stable public attribute group
+    stability: stable
+    visibility: public
+    attributes:
+      - ref: experimental.attr
+        requirement_level: recommended
+      - ref: opt_in.experimental.attr
+        requirement_level: opt_in
+  - id: internal.group
+    visibility: internal
+    attributes:
+      - ref: experimental.attr
+        requirement_level: recommended

--- a/policies/check/stability/tests/attribute_group_experimental_attribute/expected-diagnostic-output.json
+++ b/policies/check/stability/tests/attribute_group_experimental_attribute/expected-diagnostic-output.json
@@ -1,0 +1,24 @@
+[
+  {
+    "diagnostic": {
+      "message": "Policy violation: id=stability_attribute_group_lower_stability_attribute, context={\"attribute_key\":\"experimental.attr\",\"attribute_stability\":\"development\",\"signal_stability\":\"stable\"}, message=attribute_group 'stable.group' has stability 'stable' which is higher than the stability 'development' of attribute 'experimental.attr'; lower-stability attributes are only allowed at 'opt_in' requirement level, level=Violation, signal_type=Some(\"attribute_group\"), signal_name=Some(\"stable.group\"), provenance: current"
+    },
+    "error": {
+      "provenance": "current",
+      "type": "policy_violation",
+      "violation": {
+        "context": {
+          "attribute_key": "experimental.attr",
+          "attribute_stability": "development",
+          "signal_stability": "stable"
+        },
+        "id": "stability_attribute_group_lower_stability_attribute",
+        "level": "violation",
+        "message": "attribute_group 'stable.group' has stability 'stable' which is higher than the stability 'development' of attribute 'experimental.attr'; lower-stability attributes are only allowed at 'opt_in' requirement level",
+        "signal_name": "stable.group",
+        "signal_type": "attribute_group",
+        "type": "PolicyFinding"
+      }
+    }
+  }
+]


### PR DESCRIPTION
- Public attribute groups can't be removed
- Stable public attribute groups can't become unstable
- Stable public attribute groups can't drop attributes
- Stable public attribute groups can't add non-opt-in attributes
- Public attribute groups can't be more stable than their non-opt-in attributes